### PR TITLE
chore: adding CODEOWNERS because it's the right thing to do

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @esacteksab
+/.github/CODEOWNERS @esacteksab
+/.github/settings.yml @esacteksab


### PR DESCRIPTION
- This should exist, because it's the right thing to do.
