### PR TITLE
fix: adds contents: read to permissions for labeler shared workflow

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -7,7 +7,9 @@ jobs:
   labeler:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       pull-requests: write
+
     steps:
       - name: Checkout Repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
@@ -24,7 +26,7 @@ jobs:
           fi
 
           if [[ ${SCOPE} == "deps" ]]; then
-            gh pr edit ${{ github.event.pull_request.number }} --add-label "type: ${TYPE},type: dependencies"
+            gh pr edit ${{ github.event.pull_request.number }} --add-label "type: ${TYPE},dependencies"
           else
             gh pr edit ${{ github.event.pull_request.number }} --add-label "type: ${TYPE}"
           fi


### PR DESCRIPTION
This exists in an attempt to address the `labeler.yml` workflow failing on private repositories.

From GitHub support:


The repository `not found` error typically is due to lacking access permission for the repo. Checking your public example shared in your last reply, I see the reusable workflow here is:

`esacteksab/.github/.github/workflows/labeler.yml@21bd7f88fef63b0a428dcbed6db9b5020c689682` 

The actions/checkout action by default uses the workflow's `GITHUB_TOKEN` to fetch repository content, and that token's permissions are defined by the [permissions key](https://github.com/esacteksab/.github/blob/21bd7f88fef63b0a428dcbed6db9b5020c689682/.github/workflows/labeler.yml#L9-L10) here.
 
You'll want to add the contents: read [scope](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) under permissions, so that the token can access the repo's content when it's private:

```yaml
permissions:
  contents: read
  pull-requests: write
```
