### PR TITLE
fix: use single quotes to disable interpretations

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Get PR type and add label
         run: |
           gh auth setup-git
-          PRTITLE="${{ github.event.pull_request.title }}"
+          PRTITLE='${{ github.event.pull_request.title }}'
           REGEX="\(([^)]+)\)"
           if [[ ${PRTITLE} =~ ${REGEX} ]]; then
             SCOPE="${BASH_REMATCH[1]}"

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,5 +1,3 @@
-# keep-sorted start
-go 1.24.2
-node 22.14.0
-python 3.12.9
-# keep-sorted end
+golang 1.24
+nodejs 22
+python 3.12


### PR DESCRIPTION
With a PR title like "PRTITLE='chore(deps): bump golang from `00eccd4` to `915f66a`'"

It attempts to run `00eccd4` and `915f66a`

```bash
##[debug]/usr/bin/bash --noprofile --norc -e -o pipefail /home/runner/work/_temp/f9333181-8bc3-4bb9-b9a3-e95fb66c2ad5.sh
/home/runner/work/_temp/f9333181-8bc3-4bb9-b9a3-e95fb66c2ad5.sh: line 2: 00eccd4: command not found
/home/runner/work/_temp/f9333181-8bc3-4bb9-b9a3-e95fb66c2ad5.sh: line 2: 915f66a: command not found
```

Using single quotes should fix this.

- **fix: single quotes ensures no intrepretations**
- **fix: proper syntax for tool-versions**
