### PR TITLE
chore: update golangci-lint binary, not action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -30,4 +30,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 #v8.0.0
         with:
-          version: v2.1.6
+          version: v2.4.0


### PR DESCRIPTION
Updates golangci-lint binary to support go 1.25.0
