### PR TITLE
feat: add pre-commit-go workflow

### DIFF
--- a/.github/workflows/pre-commit-go.yml
+++ b/.github/workflows/pre-commit-go.yml
@@ -29,5 +29,11 @@ jobs:
           # yamllint disable-line rule:quoted-strings
           python-version: 3.12
 
+      - name: Set up Go
+        uses: actions/setup-go@44694675825211faa026b3c33043df3e48a5fa00  # v6.0.0
+        with:
+          go-version-file: go.mod
+          cache: true
+
       - name: Pre-Commit
         uses: esacteksab/pre-commit-action@4563f702b4348f0109ef6a450d90f917067815e3  # v0.1.0


### PR DESCRIPTION
Almost every repo uses `pre-commit` but not every repo uses Go and the way the `pre-commit` workflow was updated in the previous release, it sourced the Go version from `go.mod` and the absence of that file would result in `pre-commit` workflow failing because it was unable to install any version. This creates a unique workflow for those repos that use `pre-commit` and Go where a `go.mod` would exist. Maybe not the best way to solve it, but does get the job done.
